### PR TITLE
1.18 ignore dead players

### DIFF
--- a/src/main/java/com/mactso/hardernaturalhealing/forgeevents/PlayerTickHandler.java
+++ b/src/main/java/com/mactso/hardernaturalhealing/forgeevents/PlayerTickHandler.java
@@ -27,7 +27,7 @@ public class PlayerTickHandler {
 
 			// heal once per second if the player is wounded.
 			// additionally skip dead players. Some mods don't like receiving events for dead players.
-			if (!p.isDeadOrDying() || (event.phase == TickEvent.Phase.END) || (gameTime % 20 != 0) || (p.getHealth() >= p.getMaxHealth())) {
+			if (p.isDeadOrDying() || (event.phase == TickEvent.Phase.END) || (gameTime % 20 != 0) || (p.getHealth() >= p.getMaxHealth())) {
 				return;
 			}
 			

--- a/src/main/java/com/mactso/hardernaturalhealing/forgeevents/PlayerTickHandler.java
+++ b/src/main/java/com/mactso/hardernaturalhealing/forgeevents/PlayerTickHandler.java
@@ -26,7 +26,8 @@ public class PlayerTickHandler {
 			long gameTime = w.getGameTime();
 
 			// heal once per second if the player is wounded.
-			if ((event.phase == TickEvent.Phase.END) || (gameTime % 20 != 0) || (p.getHealth() >= p.getMaxHealth())) {
+			// additionally skip dead players. Some mods don't like receiving events for dead players.
+			if (!p.isDeadOrDying() || (event.phase == TickEvent.Phase.END) || (gameTime % 20 != 0) || (p.getHealth() >= p.getMaxHealth())) {
 				return;
 			}
 			


### PR DESCRIPTION
Adds a very simple check that fixes bugs with mods that hook healing events.

Specifically fixes a crash that happens when combined with a mod called "First aid" which uses a custom damage model. This model is removed on death, but HarderNaturalHealing's PlayerTick method still runs, causing First Aid to try to handle it without the model. This results in a crash on death and is fixed by adding this single condition.